### PR TITLE
UTC to Client timezone conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint": "^7.2.0",
     "express": "4.17.1",
     "jquery": "3.6.0",
+    "luxon": "2.0.2",
     "mongoose": "5.13.5",
     "node-cache": "5.1.2",
     "node-fetch": "2.6.1",

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,6 @@ const path = require("path");
 const URL = require("url").URL;
 const cookieParser = require("cookie-parser");
 const mongoose = require("mongoose");
-const {DateTime} = require("luxon");
 const getData = require("./getData");
 const getToken = require("./getToken");
 const NodeCache = require("node-cache");
@@ -97,7 +96,7 @@ app.get("/redirect", (req, res) => {
 const LogItem = require("./models/LogItem");
 
 app.get("/groups/:id/jobs", function (req, res) {
-  const timezoneOffset = getTimezoneAPI.getTimezone(
+  const clientTimezone = getTimezoneAPI.getTimezone(
     req.headers[`x-forwarded-for`]
   );
   if (req.cookies.access_token === "" || req.cookies.access_token == null) {
@@ -118,7 +117,7 @@ app.get("/groups/:id/jobs", function (req, res) {
         req.params.id,
         req.cookies.access_token,
         projects,
-        timezoneOffset
+        clientTimezone
       );
     })
     .then((data) => {
@@ -172,7 +171,7 @@ app.get("/error", (req, res) => {
 });
 
 app.get("/api/groups/:id/jobs", (req, res) => {
-  const timezoneOffset = getTimezoneAPI.getTimezone(
+  const clientTimezone = getTimezoneAPI.getTimezone(
     req.headers[`x-forwarded-for`]
   );
   getProjectIDs(req.params.id, req.cookies.access_token)
@@ -181,7 +180,7 @@ app.get("/api/groups/:id/jobs", (req, res) => {
         req.params.id,
         req.cookies.access_token,
         projectIDs,
-        timezoneOffset
+        clientTimezone
       )
     )
     .then((jobs) => {

--- a/src/app.js
+++ b/src/app.js
@@ -96,7 +96,9 @@ app.get("/redirect", (req, res) => {
 const LogItem = require("./models/LogItem");
 
 app.get("/groups/:id/jobs", function (req, res) {
-  const timezoneOffset = getTimezoneAPI.getTimezone(req.headers[`x-forwarded-for`]);
+  const timezoneOffset = getTimezoneAPI.getTimezone(
+    req.headers[`x-forwarded-for`]
+  );
   if (req.cookies.access_token === "" || req.cookies.access_token == null) {
     res.redirect(`${origin}/redirect/` + encodeURIComponent(req.originalUrl));
     return;
@@ -111,34 +113,39 @@ app.get("/groups/:id/jobs", function (req, res) {
 
   getProjectIDs(req.params.id, req.cookies.access_token)
     .then((projects) => {
-      return getJobs(req.params.id, req.cookies.access_token, projects, timezoneOffset)
+      return getJobs(
+        req.params.id,
+        req.cookies.access_token,
+        projects,
+        timezoneOffset
+      );
     })
     .then((data) => {
-      const createdJobs = data.filter((data) => data.status === "created")
-      const pendingJobs = data.filter((data) => data.status === "pending")
-      const runningJobs = data.filter((data) => data.status === "running")
-      
-      const createdCards = createdJobs.map((job)=>{
-        return{
+      const createdJobs = data.filter((data) => data.status === "created");
+      const pendingJobs = data.filter((data) => data.status === "pending");
+      const runningJobs = data.filter((data) => data.status === "running");
+
+      const createdCards = createdJobs.map((job) => {
+        return {
           name: job.project_name,
           tags: job.tag_list,
-          html: cardTemplate({job: job})
-        }
-      })
-      const pendingCards = pendingJobs.map((job)=>{
-        return{
+          html: cardTemplate({ job: job }),
+        };
+      });
+      const pendingCards = pendingJobs.map((job) => {
+        return {
           name: job.project_name,
           tags: job.tag_list,
-          html: cardTemplate({job: job})
-        }
-      })
-      const runningCards = runningJobs.map((job)=>{
-        return{
+          html: cardTemplate({ job: job }),
+        };
+      });
+      const runningCards = runningJobs.map((job) => {
+        return {
           name: job.project_name,
           tags: job.tag_list,
-          html: cardTemplate({job: job})
-        }
-      })
+          html: cardTemplate({ job: job }),
+        };
+      });
       res.render("pages/index", {
         created: createdJobs,
         pending: pendingJobs,
@@ -164,10 +171,17 @@ app.get("/error", (req, res) => {
 });
 
 app.get("/api/groups/:id/jobs", (req, res) => {
-  const timezoneOffset = getTimezoneAPI.getTimezone(req.headers[`x-forwarded-for`])
+  const timezoneOffset = getTimezoneAPI.getTimezone(
+    req.headers[`x-forwarded-for`]
+  );
   getProjectIDs(req.params.id, req.cookies.access_token)
     .then((projectIDs) =>
-      getJobs(req.params.id, req.cookies.access_token, projectIDs, timezoneOffset)
+      getJobs(
+        req.params.id,
+        req.cookies.access_token,
+        projectIDs,
+        timezoneOffset
+      )
     )
     .then((jobs) => {
       return jobs.filter((jobs) => jobs.status === req.query.status);

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const path = require("path");
 const URL = require("url").URL;
 const cookieParser = require("cookie-parser");
 const mongoose = require("mongoose");
+const {DateTime} = require("luxon");
 const getData = require("./getData");
 const getToken = require("./getToken");
 const NodeCache = require("node-cache");

--- a/src/getData.js
+++ b/src/getData.js
@@ -25,37 +25,49 @@ module.exports.getProjectIDs = function getProjectIDs(requestedGroupID, token) {
     });
 };
 
-module.exports.getJobs = function getJobs(requestedGroupID, token, projects, timezoneOffset) {
+module.exports.getJobs = function getJobs(
+  requestedGroupID,
+  token,
+  projects,
+  timezoneOffset
+) {
   const jobPromises = projects.map((project) => {
     return gitlabAPI.getJobsByProjectID(token, project.id).then((jobs) => {
       return jobs.map((job) => {
-        const zuluCreatedTime = new Date(job.created_at.replace('Z', ''))
-        const localCreatedTime = new Date(zuluCreatedTime.getTime() + (parseInt(timezoneOffset) * 36000))
-        const createdMonth = localCreatedTime.getMonth() + 1
-        const createdTimeStr = `${localCreatedTime.getFullYear()}`+
-        `/${createdMonth}`+
-        `/${localCreatedTime.getHours()}`+
-        ` ${localCreatedTime.getHours()}`+
-        `:${localCreatedTime.getMinutes()}`+
-        `:${localCreatedTime.getSeconds()}`
+        const zuluCreatedTime = new Date(job.created_at.replace("Z", ""));
+        const localCreatedTime = new Date(
+          zuluCreatedTime.getTime() + parseInt(timezoneOffset) * 36000
+        );
+        const createdMonth = localCreatedTime.getMonth() + 1;
+        const createdTimeStr =
+          `${localCreatedTime.getFullYear()}` +
+          `/${createdMonth}` +
+          `/${localCreatedTime.getHours()}` +
+          ` ${localCreatedTime.getHours()}` +
+          `:${localCreatedTime.getMinutes()}` +
+          `:${localCreatedTime.getSeconds()}`;
 
-        var startedTimeStr = "Not yet started"
-        if(job.started_at != null){
-          const zuluStartedTime = new Date(job.started_at.replace('Z',''))
-          const localStartedTime = new Date(zuluStartedTime.getTime() + (parseInt(timezoneOffset) * 36000))
-          const startedMonth = localStartedTime.getMonth() + 1
-          startedTimeStr = `${localStartedTime.getFullYear()}`+
-          `/${startedMonth}`+
-          `/${localStartedTime.getHours()}`+
-          ` ${localStartedTime.getHours()}`+
-          `:${localStartedTime.getMinutes()}`+
-          `:${localStartedTime.getSeconds()}`
+        var startedTimeStr = "Not yet started";
+        if (job.started_at != null) {
+          const zuluStartedTime = new Date(job.started_at.replace("Z", ""));
+          const localStartedTime = new Date(
+            zuluStartedTime.getTime() + parseInt(timezoneOffset) * 36000
+          );
+          const startedMonth = localStartedTime.getMonth() + 1;
+          startedTimeStr =
+            `${localStartedTime.getFullYear()}` +
+            `/${startedMonth}` +
+            `/${localStartedTime.getHours()}` +
+            ` ${localStartedTime.getHours()}` +
+            `:${localStartedTime.getMinutes()}` +
+            `:${localStartedTime.getSeconds()}`;
         }
-        return {...job, 
+        return {
+          ...job,
           project_name: project.name,
           created_at: createdTimeStr,
           started_at: startedTimeStr,
-        }
+        };
       });
     });
   });

--- a/src/getData.js
+++ b/src/getData.js
@@ -40,36 +40,7 @@ module.exports.getJobs = function getJobs(
           timezone
         );
         const startedTimeStr =
-          getLocalTime.getTimeByTimezone(job.started_at, timezone) ||
-          "Not yet started";
-        // const zuluCreatedTime = new Date(job.created_at.replace("Z", ""));
-        // const localCreatedTime = new Date(
-        //   zuluCreatedTime.getTime() + parseInt(timezoneOffset) * 36000
-        // );
-        // const createdMonth = localCreatedTime.getMonth() + 1;
-        // const createdTimeStr =
-        //   `${localCreatedTime.getFullYear()}` +
-        //   `/${createdMonth}` +
-        //   `/${localCreatedTime.getHours()}` +
-        //   ` ${localCreatedTime.getHours()}` +
-        //   `:${localCreatedTime.getMinutes()}` +
-        //   `:${localCreatedTime.getSeconds()}`;
-
-        // var startedTimeStr = "Not yet started";
-        // if (job.started_at != null) {
-        //   const zuluStartedTime = new Date(job.started_at.replace("Z", ""));
-        //   const localStartedTime = new Date(
-        //     zuluStartedTime.getTime() + parseInt(timezoneOffset) * 36000
-        //   );
-        //   const startedMonth = localStartedTime.getMonth() + 1;
-        //   startedTimeStr =
-        //     `${localStartedTime.getFullYear()}` +
-        //     `/${startedMonth}` +
-        //     `/${localStartedTime.getHours()}` +
-        //     ` ${localStartedTime.getHours()}` +
-        //     `:${localStartedTime.getMinutes()}` +
-        //     `:${localStartedTime.getSeconds()}`;
-        // }
+          getLocalTime.getTimeByTimezone(job.started_at, timezone) || "Not yet started";
         return {
           ...job,
           project_name: project.name,

--- a/src/getData.js
+++ b/src/getData.js
@@ -25,10 +25,38 @@ module.exports.getProjectIDs = function getProjectIDs(requestedGroupID, token) {
     });
 };
 
-module.exports.getJobs = function getJobs(requestedGroupID, token, projects) {
+module.exports.getJobs = function getJobs(requestedGroupID, token, projects, timezoneOffset) {
   const jobPromises = projects.map((project) => {
     return gitlabAPI.getJobsByProjectID(token, project.id).then((jobs) => {
-      return jobs.map((job) => ({ ...job, project_name: project.name }));
+      return jobs.map((job) => {
+        const zuluCreatedTime = new Date(job.created_at.replace('Z', ''))
+        const localCreatedTime = new Date(zuluCreatedTime.getTime() + (parseInt(timezoneOffset) * 36000))
+        const createdMonth = localCreatedTime.getMonth() + 1
+        const createdTimeStr = `${localCreatedTime.getFullYear()}`+
+        `/${createdMonth}`+
+        `/${localCreatedTime.getHours()}`+
+        ` ${localCreatedTime.getHours()}`+
+        `:${localCreatedTime.getMinutes()}`+
+        `:${localCreatedTime.getSeconds()}`
+
+        var startedTimeStr = "Not yet started"
+        if(job.started_at != null){
+          const zuluStartedTime = new Date(job.started_at.replace('Z',''))
+          const localStartedTime = new Date(zuluStartedTime.getTime() + (parseInt(timezoneOffset) * 36000))
+          const startedMonth = localStartedTime.getMonth() + 1
+          startedTimeStr = `${localStartedTime.getFullYear()}`+
+          `/${startedMonth}`+
+          `/${localStartedTime.getHours()}`+
+          ` ${localStartedTime.getHours()}`+
+          `:${localStartedTime.getMinutes()}`+
+          `:${localStartedTime.getSeconds()}`
+        }
+        return {...job, 
+          project_name: project.name,
+          created_at: createdTimeStr,
+          started_at: startedTimeStr,
+        }
+      });
     });
   });
   return Promise.all(jobPromises).then((data) => {

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,4 +1,5 @@
 const gitlabAPI = require("./gitlabAPI");
+const getLocalTime = require("./getLocalTime");
 
 module.exports.getProjectIDs = function getProjectIDs(requestedGroupID, token) {
   const apiToken = token;
@@ -29,39 +30,46 @@ module.exports.getJobs = function getJobs(
   requestedGroupID,
   token,
   projects,
-  timezoneOffset
+  timezone
 ) {
   const jobPromises = projects.map((project) => {
     return gitlabAPI.getJobsByProjectID(token, project.id).then((jobs) => {
       return jobs.map((job) => {
-        const zuluCreatedTime = new Date(job.created_at.replace("Z", ""));
-        const localCreatedTime = new Date(
-          zuluCreatedTime.getTime() + parseInt(timezoneOffset) * 36000
+        const createdTimeStr = getLocalTime.getTimeByTimezone(
+          job.created_at,
+          timezone
         );
-        const createdMonth = localCreatedTime.getMonth() + 1;
-        const createdTimeStr =
-          `${localCreatedTime.getFullYear()}` +
-          `/${createdMonth}` +
-          `/${localCreatedTime.getHours()}` +
-          ` ${localCreatedTime.getHours()}` +
-          `:${localCreatedTime.getMinutes()}` +
-          `:${localCreatedTime.getSeconds()}`;
+        const startedTimeStr =
+          getLocalTime.getTimeByTimezone(job.started_at, timezone) ||
+          "Not yet started";
+        // const zuluCreatedTime = new Date(job.created_at.replace("Z", ""));
+        // const localCreatedTime = new Date(
+        //   zuluCreatedTime.getTime() + parseInt(timezoneOffset) * 36000
+        // );
+        // const createdMonth = localCreatedTime.getMonth() + 1;
+        // const createdTimeStr =
+        //   `${localCreatedTime.getFullYear()}` +
+        //   `/${createdMonth}` +
+        //   `/${localCreatedTime.getHours()}` +
+        //   ` ${localCreatedTime.getHours()}` +
+        //   `:${localCreatedTime.getMinutes()}` +
+        //   `:${localCreatedTime.getSeconds()}`;
 
-        var startedTimeStr = "Not yet started";
-        if (job.started_at != null) {
-          const zuluStartedTime = new Date(job.started_at.replace("Z", ""));
-          const localStartedTime = new Date(
-            zuluStartedTime.getTime() + parseInt(timezoneOffset) * 36000
-          );
-          const startedMonth = localStartedTime.getMonth() + 1;
-          startedTimeStr =
-            `${localStartedTime.getFullYear()}` +
-            `/${startedMonth}` +
-            `/${localStartedTime.getHours()}` +
-            ` ${localStartedTime.getHours()}` +
-            `:${localStartedTime.getMinutes()}` +
-            `:${localStartedTime.getSeconds()}`;
-        }
+        // var startedTimeStr = "Not yet started";
+        // if (job.started_at != null) {
+        //   const zuluStartedTime = new Date(job.started_at.replace("Z", ""));
+        //   const localStartedTime = new Date(
+        //     zuluStartedTime.getTime() + parseInt(timezoneOffset) * 36000
+        //   );
+        //   const startedMonth = localStartedTime.getMonth() + 1;
+        //   startedTimeStr =
+        //     `${localStartedTime.getFullYear()}` +
+        //     `/${startedMonth}` +
+        //     `/${localStartedTime.getHours()}` +
+        //     ` ${localStartedTime.getHours()}` +
+        //     `:${localStartedTime.getMinutes()}` +
+        //     `:${localStartedTime.getSeconds()}`;
+        // }
         return {
           ...job,
           project_name: project.name,

--- a/src/getLocalTime.js
+++ b/src/getLocalTime.js
@@ -1,0 +1,20 @@
+const { DateTime } = require("luxon");
+
+exports.getTimeByTimezone = function getTimeByTimezone(zuluTime, timezone) {
+  if (zuluTime == null) {
+    return;
+  }
+  const timeObj = DateTime.fromISO(zuluTime);
+  const convertedTime = DateTime.fromObject(
+    {
+      year: timeObj.year,
+      month: timeObj.month,
+      day: timeObj.day,
+      hour: timeObj.hour,
+      minute: timeObj.minute,
+      second: timeObj.second,
+    },
+    { zone: timezone }
+  );
+  return convertedTime.toLocaleString(DateTime.DATETIME_MED);
+};

--- a/src/getTimezoneAPI.js
+++ b/src/getTimezoneAPI.js
@@ -1,0 +1,6 @@
+const fetch = require("node-fetch");
+
+exports.getTimezone = function getTimezone(clientIP){
+    const clientInfo = fetch(`https://ipapi.co/${clientIP}/json`)
+    return clientInfo.utc_offset || "+0800" //Default : Hong Kong
+}

--- a/src/getTimezoneAPI.js
+++ b/src/getTimezoneAPI.js
@@ -2,5 +2,5 @@ const fetch = require("node-fetch");
 
 exports.getTimezone = function getTimezone(clientIP) {
   const clientInfo = fetch(`https://ipapi.co/${clientIP}/json`);
-  return clientInfo.utc_offset || "+0800"; //Default : Hong Kong
+  return clientInfo.timezone || "Asia/Hong_Kong"; //Default
 };

--- a/src/getTimezoneAPI.js
+++ b/src/getTimezoneAPI.js
@@ -1,6 +1,6 @@
 const fetch = require("node-fetch");
 
-exports.getTimezone = function getTimezone(clientIP){
-    const clientInfo = fetch(`https://ipapi.co/${clientIP}/json`)
-    return clientInfo.utc_offset || "+0800" //Default : Hong Kong
-}
+exports.getTimezone = function getTimezone(clientIP) {
+  const clientInfo = fetch(`https://ipapi.co/${clientIP}/json`);
+  return clientInfo.utc_offset || "+0800"; //Default : Hong Kong
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,6 +1884,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
+  integrity sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
@Steven-Chan 
Added:
- Server (app.js) will now get ip from req.headers[`x-forwarded-for`]
- New getTimezoneAPI.js 
  - to get timezone offset from ipapi.co by client ip

Changes:
- Added "Not yet started" to empty time fields
- Display time format has been changed:
<img width="483" alt="Screenshot 2021-09-09 at 7 46 29 PM" src="https://user-images.githubusercontent.com/85364009/132682450-4b3fe0c0-441d-498d-8284-b6dc0441dd5f.png">

Issue: 
- Require Ngnix to verify if the server can get ip by the header
- Default is manually set to +0800
- Previous PR requires changes, will have to rebase afterwards